### PR TITLE
fix breaking changes of pocket api

### DIFF
--- a/src/pockexport/export.py
+++ b/src/pockexport/export.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import json
 
 import pocket  # type: ignore
+
+from .exporthelpers.export_helper import Json
+from .exporthelpers.logging_helper import make_logger
+
+## useful for debugging
+# from http.client import HTTPConnection
+# HTTPConnection.debuglevel = 1
+###
+
+logger = make_logger(__name__, level='debug')
 
 
 class Exporter:
@@ -15,25 +27,47 @@ class Exporter:
         def get(self, **kwargs):
             pass
 
-        # apparently no pagination?
-        res = get(
-            self.api,
-            images=1,
-            videos=1,
-            tags=1,
-            rediscovery=1,
-            annotations=1,
-            authors=1,
-            itemOptics=1,
-            meta=1,
-            posts=1,
-            total=1,
-            forceaccount=1,
-            state='all',
-            sort='newest',
-            detailType='complete',
-        )
-        return res[0]
+        all_items: dict[str, Json] = {}
+
+        first_res: Json | None = None
+        total: int | None = None
+
+        while True:
+            offset = len(all_items)
+            logger.debug(f'retrieving from {offset=} (expected {total=})')
+            res, _headers = get(
+                self.api,
+                images=1,
+                videos=1,
+                tags=1,
+                rediscovery=1,
+                annotations=1,
+                authors=1,
+                itemOptics=1,
+                meta=1,
+                posts=1,
+                total=1,
+                forceaccount=1,
+                offset=offset,
+                count=30,  # max count per request according to api docs
+                state='all',
+                sort='newest',
+                detailType='complete',
+            )
+            if first_res is None:
+                first_res = res
+
+            assert res.get('error') is None, res  # just in case
+            total = int(res['total'])
+
+            new_items: dict[str, Json] = res['list']
+            if len(new_items) == 0:
+                break
+
+            all_items.update(new_items)
+
+        first_res['list'] = all_items  # eh, hacky, but not sure what's a better way
+        return first_res
 
 
 def get_json(**params):
@@ -54,13 +88,15 @@ def main() -> None:
 
 def make_parser():
     from .exporthelpers.export_helper import Parser, setup_parser
+
     parser = Parser('Export your personal Pocket data, *including highlights* as JSON.')
     setup_parser(
         parser=parser,
         params=['consumer_key', 'access_token'],
         extra_usage='''
 You can also import ~pockexport.export~ as a module and call ~get_json~ function directly to get raw JSON.
-''')
+''',
+    )
     return parser
 
 


### PR DESCRIPTION
Since recently, pocket started to
- returning all items including previously deleted? we filter them out in DAL now since they don't have any actual data
- return created_at timestamp for highlights as isoformat ending with Z (however this seems to be an incorrect timestamp -- not sure if it used to be correct previously)

Seems like the only mention of any changes is this https://x.com/smarachefr/status/1839571167373369640

Not sure if there is anything else, but this results in same data as previously now at least